### PR TITLE
[docs] add comment for rust::Str size and length

### DIFF
--- a/book/src/binding/str.md
+++ b/book/src/binding/str.md
@@ -28,7 +28,9 @@ public:
 
   // Note: no null terminator.
   const char *data() const noexcept;
+  // Length in bytes
   size_t size() const noexcept;
+  // Length in bytes, alias for `size()`
   size_t length() const noexcept;
   bool empty() const noexcept;
 


### PR DESCRIPTION
The presence of `size` and `length` confused me, adding a small comment to make it more clear for future readers.